### PR TITLE
Spawn flora clusters on eligible mineral hexes (1-3 per cluster)

### DIFF
--- a/crates/flora/README.md
+++ b/crates/flora/README.md
@@ -29,7 +29,7 @@ let cfg = FloraCfg::default();
 let assets = FloraMaterials::new(&mut materials, &mut meshes, &cfg);
 
 // Spawn clusters (1-3 mushrooms each)
-let entities = shimeji_cluster(&mut commands, &assets, &cfg, pos, 2);
+let (cluster, roots) = shimeji_cluster(&mut commands, &assets, &cfg, pos, 2);
 ```
 
 ### Cluster sizes

--- a/crates/flora/src/cluster.rs
+++ b/crates/flora/src/cluster.rs
@@ -21,7 +21,7 @@ pub fn shimeji_cluster(
     cfg: &FloraCfg,
     pos: Vec3,
     num: u8,
-) -> Vec<Entity> {
+) -> (Entity, Vec<Entity>) {
     let num = num.clamp(1, 3);
     let mut roots = Vec::with_capacity(num as usize);
 
@@ -53,7 +53,7 @@ pub fn shimeji_cluster(
         roots.push(spawn_one(commands, assets, cfg, cluster, tf));
     }
 
-    roots
+    (cluster, roots)
 }
 
 /// Spawn one mushroom as child of `parent` with local `tf`.

--- a/src/h_terrain.rs
+++ b/src/h_terrain.rs
@@ -3,6 +3,7 @@
 pub(crate) mod biome;
 pub(crate) mod biomes;
 mod entities;
+mod flora_spawn;
 mod gaps;
 mod h_grid_layout;
 pub(crate) mod materials;
@@ -84,6 +85,8 @@ pub struct HGridSettings {
     pub radius_noise_seed: u32,
     /// Seed for deterministic mineral assignment per hex.
     pub mineral_seed: u32,
+    /// Seed for deterministic flora spawn rolls per hex.
+    pub flora_seed: u32,
     /// Number of octaves for height noise.
     pub height_noise_octaves: usize,
     /// Number of octaves for radius noise.
@@ -131,6 +134,7 @@ impl Default for HTerrainConfig {
                 height_noise_seed: 43,
                 radius_noise_seed: 137,
                 mineral_seed: 7919,
+                flora_seed: 1979,
                 height_noise_octaves: 4,
                 radius_noise_octaves: 3,
                 height_noise_scale: 50.0,

--- a/src/h_terrain/biome.rs
+++ b/src/h_terrain/biome.rs
@@ -57,7 +57,7 @@ impl Biome {
     ///
     /// Delegates to [`Mineral::flora_freq`] — the biome controls *which*
     /// minerals appear, each mineral carries its own flora propensity.
-    #[allow(dead_code)] // planned for biome-driven flora spawning
+    #[allow(dead_code)] // used in tests; production code calls Mineral::flora_freq() directly
     pub fn flora_freq(&self, mineral: Mineral) -> f32 {
         mineral.flora_freq()
     }

--- a/src/h_terrain/flora_spawn.rs
+++ b/src/h_terrain/flora_spawn.rs
@@ -1,0 +1,67 @@
+//! Flora cluster spawning during terrain generation.
+
+use bevy::platform::collections::HashMap;
+use bevy::prelude::*;
+use hexx::Hex;
+
+use flora::cluster::shimeji_cluster;
+use flora::{FloraCfg, FloraMaterials};
+
+use super::mineral::{Mineral, hash_hex};
+
+/// Spawn shimeji clusters on hexes whose mineral supports flora.
+///
+/// Each eligible hex gets a deterministic spawn check against
+/// `Mineral::flora_freq()`, with cluster size 1-3 from a second hash.
+/// Clusters are parented to the corresponding HCell entity.
+pub(super) fn spawn_flora(
+    commands: &mut Commands,
+    assets: &FloraMaterials,
+    cfg: &FloraCfg,
+    hex_minerals: &HashMap<Hex, Mineral>,
+    hex_entities: &HashMap<Hex, Entity>,
+    flora_seed: u32,
+) {
+    for (&hex, &mineral) in hex_minerals {
+        let freq = mineral.flora_freq();
+        if freq <= 0.0 {
+            continue;
+        }
+
+        let h = hash_hex(hex, flora_seed);
+        let roll = (h % 10000) as f32 / 10000.0;
+        if roll >= freq {
+            continue;
+        }
+
+        let h2 = hash_hex(hex, flora_seed.wrapping_add(1));
+        let num = (h2 % 3) as u8 + 1;
+
+        let (cluster, _roots) = shimeji_cluster(commands, assets, cfg, Vec3::ZERO, num);
+
+        if let Some(&cell) = hex_entities.get(&hex) {
+            commands.entity(cell).add_child(cluster);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_flora_on_zero_freq() {
+        assert_eq!(Mineral::Granite.flora_freq(), 0.0);
+        assert_eq!(Mineral::Basalt.flora_freq(), 0.0);
+        assert!(Mineral::Sandstone.flora_freq() > 0.0);
+    }
+
+    #[test]
+    fn hash_cluster_size_range() {
+        for i in 0..100 {
+            let h = hash_hex(Hex::new(i, 0), 1980);
+            let num = (h % 3) as u8 + 1;
+            assert!((1..=3).contains(&num));
+        }
+    }
+}

--- a/src/h_terrain/startup_systems.rs
+++ b/src/h_terrain/startup_systems.rs
@@ -7,6 +7,7 @@ use bevy::prelude::*;
 use bevy::render::render_resource::PrimitiveTopology;
 use hexx::{Hex, HexLayout, PlaneMeshBuilder, shapes};
 
+use flora::{FloraCfg, FloraMaterials};
 use mesh_gradient::BlendCfg;
 
 use super::HTerrainConfig;
@@ -32,6 +33,8 @@ pub fn generate_h_grid(
 
     let edge_thickness = 0.02;
     let fov = TerrainMaterials::new(&mut materials, &mut meshes, &mut images);
+    let flora_cfg = FloraCfg::default();
+    let flora_mat = FloraMaterials::new(&mut materials, &mut meshes, &flora_cfg);
     let debug_assets = debug.0.then(|| {
         let sphere_mesh = meshes.add(Sphere::new(0.08));
         let material = TerrainMaterials::debug_material(&mut materials);
@@ -181,6 +184,16 @@ pub fn generate_h_grid(
             }
         }
     }
+
+    // ── Pass 3: Flora clusters on eligible hexes ─────────────────
+    super::flora_spawn::spawn_flora(
+        &mut commands,
+        &flora_mat,
+        &flora_cfg,
+        &hex_minerals,
+        &hex_entities,
+        g.flora_seed,
+    );
 
     commands.entity(grid_entity).insert(HGrid {
         terrain,

--- a/src/h_terrain/tests.rs
+++ b/src/h_terrain/tests.rs
@@ -22,6 +22,7 @@ fn test_config() -> HTerrainConfig {
             height_noise_seed: 43,
             radius_noise_seed: 137,
             mineral_seed: 7919,
+            flora_seed: 1979,
             height_noise_octaves: 4,
             radius_noise_octaves: 3,
             height_noise_scale: 50.0,


### PR DESCRIPTION
Wire up the existing flora crate during terrain generation: each hex with non-zero Mineral::flora_freq() gets a deterministic spawn roll, producing shimeji mushroom clusters of 1-3 as HCell children.