### PR TITLE
fix: derive wasm-bindgen-cli version from Cargo.lock

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -64,7 +64,10 @@ jobs:
           workspaces: src
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version 0.2.108
+        working-directory: src
+        run: |
+          VER=$(grep -A1 '^name = "wasm-bindgen"$' Cargo.lock | grep version | head -1 | cut -d'"' -f2)
+          cargo install wasm-bindgen-cli --version "$VER"
 
       - name: Build WASM
         working-directory: src

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: clean build test coverage coverage-xml inject-updates wasm wasm-deps serve
 
 WASM_OUT = target/wasm
+WASM_BINDGEN_VER := $(shell grep -A1 '^name = "wasm-bindgen"$$' Cargo.lock | grep version | head -1 | cut -d'"' -f2)
 
 LATEST_TAG := $(shell git tag --sort=-v:refname | grep -m1 '^v[0-9]' || echo "")
 VERSION ?= $(if $(LATEST_TAG),$(shell echo $(LATEST_TAG) | awk -F. '{print $$1"."$$2"."$$3+1}'),v0.0.0)
@@ -30,7 +31,7 @@ inject-updates:
 
 wasm-deps:
 	rustup target add wasm32-unknown-unknown
-	cargo install wasm-bindgen-cli
+	cargo install wasm-bindgen-cli --version $(WASM_BINDGEN_VER)
 
 wasm:
 	cargo build --release --target wasm32-unknown-unknown \
@@ -41,7 +42,7 @@ wasm:
 	wasm-bindgen --out-dir $(WASM_OUT) --target web \
 		target/wasm32-unknown-unknown/release/hex-terrain.wasm \
 		|| { echo "wasm-bindgen not found — installing and retrying..."; \
-		     cargo install wasm-bindgen-cli && wasm-bindgen --out-dir $(WASM_OUT) --target web \
+		     cargo install wasm-bindgen-cli --version $(WASM_BINDGEN_VER) && wasm-bindgen --out-dir $(WASM_OUT) --target web \
 		     target/wasm32-unknown-unknown/release/hex-terrain.wasm; }
 	cp -r assets $(WASM_OUT)/
 	cp web/index.html $(WASM_OUT)/


### PR DESCRIPTION
## Summary

- The v0.0.7 Pages deploy failed because `wasm-bindgen-cli` was pinned to 0.2.108 in CI, but `Cargo.lock` has `wasm-bindgen` at 0.2.117 — a schema version mismatch
- Now both `pages.yml` and `Makefile` extract the version dynamically from `Cargo.lock` so they can never drift apart

## Test plan

- [ ] Verify `make -n wasm` shows `--version 0.2.117` in the install commands
- [ ] Re-trigger the Pages workflow with `gh workflow run pages.yml -f tag=v0.0.7` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)