### PR TITLE
hex-grid: add --rich flag to svg example

### DIFF
--- a/.github/workflows/svg-preview.yml
+++ b/.github/workflows/svg-preview.yml
@@ -22,14 +22,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
 
-      - name: Generate SVG
-        run: cargo run -p hex-grid --example svg --release -- 2 0.6 > hex-grid.svg
+      - name: Generate SVGs
+        run: |
+          cargo run -p hex-grid --example svg --release -- 2 0.6 > hex-grid.svg
+          cargo run -p hex-grid --example svg --release -- 2 0.6 --rich > hex-grid-rich.svg
 
       - name: Prepare page
         run: |
           SHORT_SHA="${GITHUB_SHA::7}"
           mkdir -p deploy
-          cp hex-grid.svg deploy/
+          cp hex-grid.svg hex-grid-rich.svg deploy/
           sed "s|__SHA__|${SHORT_SHA}|g" web/svg-preview.html > deploy/index.html
 
       - name: Deploy to gh-pages/svg

--- a/.github/workflows/svg-preview.yml
+++ b/.github/workflows/svg-preview.yml
@@ -22,17 +22,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
 
-      - name: Generate SVGs
-        run: |
-          cargo run -p hex-grid --example svg --release -- 2 0.6 > hex-grid.svg
-          cargo run -p hex-grid --example svg --release -- 2 0.6 --rich > hex-grid-rich.svg
-
-      - name: Prepare page
-        run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          mkdir -p deploy
-          cp hex-grid.svg hex-grid-rich.svg deploy/
-          sed "s|__SHA__|${SHORT_SHA}|g" web/svg-preview.html > deploy/index.html
+      - name: Build preview
+        run: make svg-preview SHORT_SHA="${GITHUB_SHA::7}" SVG_OUT=deploy
 
       - name: Deploy to gh-pages/svg
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: clean build test coverage coverage-xml inject-updates wasm wasm-deps serve
+.PHONY: clean build test coverage coverage-xml inject-updates wasm wasm-deps serve \
+	svg-preview svg-plain svg-rich svg-json svg-html svg-prep
 
 WASM_OUT = target/wasm
 WASM_BINDGEN_VER := $(shell grep -A1 '^name = "wasm-bindgen"$$' Cargo.lock | grep version | head -1 | cut -d'"' -f2)
 
 LATEST_TAG := $(shell git tag --sort=-v:refname | grep -m1 '^v[0-9]' || echo "")
 VERSION ?= $(if $(LATEST_TAG),$(shell echo $(LATEST_TAG) | awk -F. '{print $$1"."$$2"."$$3+1}'),v0.0.0)
+
+SVG_OUT ?= target/svg-preview
+SVG_RADIUS ?= 2
+SVG_PAD ?= 0.6
+SHORT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo local)
 
 clean:
 	cargo clean
@@ -50,3 +56,21 @@ wasm:
 
 serve: wasm
 	python3 -m http.server 8080 --directory $(WASM_OUT)
+
+svg-prep:
+	@mkdir -p $(SVG_OUT)
+
+svg-plain: svg-prep
+	cargo run -q -p hex-grid --example svg --release -- $(SVG_RADIUS) $(SVG_PAD) > $(SVG_OUT)/hex-grid.svg
+
+svg-rich: svg-prep
+	cargo run -q -p hex-grid --example svg --release -- $(SVG_RADIUS) $(SVG_PAD) --rich > $(SVG_OUT)/hex-grid-rich.svg
+
+svg-json: svg-prep
+	cargo run -q -p hex-grid --example svg --release -- $(SVG_RADIUS) $(SVG_PAD) --json > $(SVG_OUT)/hex-grid.json
+
+svg-html: svg-prep
+	sed "s|__SHA__|$(SHORT_SHA)|g" web/svg-preview.html > $(SVG_OUT)/index.html
+
+svg-preview: svg-plain svg-rich svg-json svg-html
+	@echo "svg preview built in $(SVG_OUT)/"

--- a/crates/hex-grid/README.md
+++ b/crates/hex-grid/README.md
@@ -1,5 +1,11 @@
 # hex-grid
 
+## 🌐 [**Live WebGL demo →**](https://dynnamitt.github.io/hex-terrain/svg/)
+
+Interactive three.js terrain viewer (orbit / zoom / pan) rendered from the crate's own `--json` output. The same page also shows the plain and rich SVG variants.
+
+---
+
 Hex grid geometry library: noise-driven terrain layout, spatial math, and gap analysis.
 
 Zero game-engine dependencies -- uses `glam` for vectors, `hexx` for hex coordinates, and `noise` for Fbm terrain generation.
@@ -23,13 +29,20 @@ let vertex = layout.vertex(hexx::Hex::ZERO, 0);
 let ground = layout.interpolate_height(glam::Vec2::new(5.0, 3.0));
 ```
 
-## SVG example
+## Preview example
 
-Renders the grid to stdout as an SVG:
+The `svg` example renders the grid to stdout in three formats. It's the same binary that drives the [live WebGL demo](https://dynnamitt.github.io/hex-terrain/svg/):
 
 ```sh
-cargo run -p hex-grid --example svg > grid.svg
-cargo run -p hex-grid --example svg -- 5 2.0 > grid.svg  # radius=5, padding=2.0
+cargo run -p hex-grid --example svg > grid.svg                 # plain SVG (gray, no labels)
+cargo run -p hex-grid --example svg -- 5 2.0 --rich > grid.svg # green fill, outlined strokes, height labels
+cargo run -p hex-grid --example svg -- 5 2.0 --json > grid.json # {hexes, edges} for three.js consumption
+```
+
+To build the whole preview page (both SVGs + JSON + HTML) locally, use the root Makefile target:
+
+```sh
+make svg-preview   # writes into target/svg-preview/
 ```
 
 ## Dependencies

--- a/crates/hex-grid/examples/svg.rs
+++ b/crates/hex-grid/examples/svg.rs
@@ -73,8 +73,10 @@ fn main() {
         })
         .collect();
 
+    let long_edges = layout.quad_long_edges();
+
     if json {
-        let entries: Vec<String> = hex_data
+        let hex_entries: Vec<String> = hex_data
             .iter()
             .map(|hd| {
                 let corners: Vec<String> = hd
@@ -91,7 +93,20 @@ fn main() {
                 )
             })
             .collect();
-        println!("[{}]", entries.join(","));
+        let edge_entries: Vec<String> = long_edges
+            .iter()
+            .map(|(a, b)| {
+                format!(
+                    r#"[[{:.4},{:.4},{:.4}],[{:.4},{:.4},{:.4}]]"#,
+                    a.x, a.y, a.z, b.x, b.y, b.z,
+                )
+            })
+            .collect();
+        println!(
+            "{{\"hexes\":[{}],\"edges\":[{}]}}",
+            hex_entries.join(","),
+            edge_entries.join(","),
+        );
         return;
     }
 
@@ -174,28 +189,26 @@ fn main() {
         }
     }
 
-    // ── Quad gap long edges ─────────────────────────────────────
-
-    let long_edges = layout.quad_long_edges();
+    // ── Quad gap long edges (projected to XZ plane) ─────────────
 
     if rich {
         for (from, to) in &long_edges {
             println!(
                 r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="white" stroke-width="{outline:.2}" stroke-linecap="round"/>"##,
-                from.x, from.y, to.x, to.y,
+                from.x, from.z, to.x, to.z,
             );
         }
         for (from, to) in &long_edges {
             println!(
                 r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="black" stroke-width="{stroke:.2}" stroke-linecap="round"/>"##,
-                from.x, from.y, to.x, to.y,
+                from.x, from.z, to.x, to.z,
             );
         }
     } else {
         for (from, to) in &long_edges {
             println!(
                 r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="gray" stroke-width="{stroke:.2}" stroke-linecap="round"/>"##,
-                from.x, from.y, to.x, to.y,
+                from.x, from.z, to.x, to.z,
             );
         }
     }

--- a/crates/hex-grid/examples/svg.rs
+++ b/crates/hex-grid/examples/svg.rs
@@ -3,15 +3,27 @@
 //! ```sh
 //! cargo run -p hex-grid --example svg > grid.svg
 //! cargo run -p hex-grid --example svg -- 5 2.0 > grid.svg
+//! cargo run -p hex-grid --example svg -- 5 2.0 --rich > grid.svg
 //! ```
 
 use hex_grid::{HGridLayout, HGridSettings};
 use hexx::{Hex, shapes};
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let radius: u32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(3);
-    let pad: f32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(4.0);
+    let mut positional: Vec<String> = Vec::new();
+    let mut rich = false;
+    for arg in std::env::args().skip(1) {
+        if arg == "--rich" {
+            rich = true;
+        } else {
+            positional.push(arg);
+        }
+    }
+    let radius: u32 = positional.first().and_then(|s| s.parse().ok()).unwrap_or(3);
+    let pad: f32 = positional
+        .get(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4.0);
 
     let settings = HGridSettings {
         radius,
@@ -77,9 +89,16 @@ fn main() {
 
     for hd in &hex_data {
         let t = if max_h > 0.0 { hd.height / max_h } else { 0.0 };
-        let r = (40.0 + t * 80.0) as u8;
-        let g = (60.0 + t * 180.0) as u8;
-        let b = (30.0 + t * 40.0) as u8;
+        let (r, g, b) = if rich {
+            (
+                (40.0 + t * 80.0) as u8,
+                (60.0 + t * 180.0) as u8,
+                (30.0 + t * 40.0) as u8,
+            )
+        } else {
+            let v = (60.0 + t * 160.0) as u8;
+            (v, v, v)
+        };
 
         let points: String = hd
             .corners
@@ -92,56 +111,81 @@ fn main() {
         );
     }
 
-    // ── Hex face outlines (white outline, then black stroke) ────
+    // ── Hex face outlines ───────────────────────────────────────
 
-    for hd in &hex_data {
-        let points: String = hd
-            .corners
-            .iter()
-            .map(|(x, z)| format!("{x:.2},{z:.2}"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        println!(
-            r##"  <polygon points="{points}" fill="none" stroke="white" stroke-width="{outline:.2}" stroke-linejoin="round"/>"##,
-        );
-    }
-    for hd in &hex_data {
-        let points: String = hd
-            .corners
-            .iter()
-            .map(|(x, z)| format!("{x:.2},{z:.2}"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        println!(
-            r##"  <polygon points="{points}" fill="none" stroke="black" stroke-width="{stroke:.2}" stroke-linejoin="round"/>"##,
-        );
+    if rich {
+        for hd in &hex_data {
+            let points: String = hd
+                .corners
+                .iter()
+                .map(|(x, z)| format!("{x:.2},{z:.2}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            println!(
+                r##"  <polygon points="{points}" fill="none" stroke="white" stroke-width="{outline:.2}" stroke-linejoin="round"/>"##,
+            );
+        }
+        for hd in &hex_data {
+            let points: String = hd
+                .corners
+                .iter()
+                .map(|(x, z)| format!("{x:.2},{z:.2}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            println!(
+                r##"  <polygon points="{points}" fill="none" stroke="black" stroke-width="{stroke:.2}" stroke-linejoin="round"/>"##,
+            );
+        }
+    } else {
+        for hd in &hex_data {
+            let points: String = hd
+                .corners
+                .iter()
+                .map(|(x, z)| format!("{x:.2},{z:.2}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            println!(
+                r##"  <polygon points="{points}" fill="none" stroke="gray" stroke-width="{stroke:.2}" stroke-linejoin="round"/>"##,
+            );
+        }
     }
 
-    // ── Quad gap long edges (white outline, then black stroke) ──
+    // ── Quad gap long edges ─────────────────────────────────────
 
     let long_edges = layout.quad_long_edges();
 
-    for (from, to) in &long_edges {
-        println!(
-            r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="white" stroke-width="{outline:.2}" stroke-linecap="round"/>"##,
-            from.x, from.y, to.x, to.y,
-        );
-    }
-    for (from, to) in &long_edges {
-        println!(
-            r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="black" stroke-width="{stroke:.2}" stroke-linecap="round"/>"##,
-            from.x, from.y, to.x, to.y,
-        );
+    if rich {
+        for (from, to) in &long_edges {
+            println!(
+                r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="white" stroke-width="{outline:.2}" stroke-linecap="round"/>"##,
+                from.x, from.y, to.x, to.y,
+            );
+        }
+        for (from, to) in &long_edges {
+            println!(
+                r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="black" stroke-width="{stroke:.2}" stroke-linecap="round"/>"##,
+                from.x, from.y, to.x, to.y,
+            );
+        }
+    } else {
+        for (from, to) in &long_edges {
+            println!(
+                r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="gray" stroke-width="{stroke:.2}" stroke-linecap="round"/>"##,
+                from.x, from.y, to.x, to.y,
+            );
+        }
     }
 
-    // ── Height labels ───────────────────────────────────────────
+    // ── Height labels (rich only) ───────────────────────────────
 
-    let font = settings.point_spacing * 0.22;
-    for hd in &hex_data {
-        println!(
-            r##"  <text x="{:.2}" y="{:.2}" font-size="{font:.2}" font-family="monospace" fill="black" text-anchor="middle" dominant-baseline="central">{:.1}</text>"##,
-            hd.center.x, hd.center.y, hd.height,
-        );
+    if rich {
+        let font = settings.point_spacing * 0.22;
+        for hd in &hex_data {
+            println!(
+                r##"  <text x="{:.2}" y="{:.2}" font-size="{font:.2}" font-family="monospace" fill="black" text-anchor="middle" dominant-baseline="central">{:.1}</text>"##,
+                hd.center.x, hd.center.y, hd.height,
+            );
+        }
     }
 
     println!("</svg>");

--- a/crates/hex-grid/examples/svg.rs
+++ b/crates/hex-grid/examples/svg.rs
@@ -1,9 +1,10 @@
-//! Renders the hex grid as an SVG file to stdout.
+//! Renders the hex grid as an SVG file to stdout, or as JSON with `--json`.
 //!
 //! ```sh
 //! cargo run -p hex-grid --example svg > grid.svg
 //! cargo run -p hex-grid --example svg -- 5 2.0 > grid.svg
 //! cargo run -p hex-grid --example svg -- 5 2.0 --rich > grid.svg
+//! cargo run -p hex-grid --example svg -- 5 2.0 --json > grid.json
 //! ```
 
 use hex_grid::{HGridLayout, HGridSettings};
@@ -12,11 +13,12 @@ use hexx::{Hex, shapes};
 fn main() {
     let mut positional: Vec<String> = Vec::new();
     let mut rich = false;
+    let mut json = false;
     for arg in std::env::args().skip(1) {
-        if arg == "--rich" {
-            rich = true;
-        } else {
-            positional.push(arg);
+        match arg.as_str() {
+            "--rich" => rich = true,
+            "--json" => json = true,
+            _ => positional.push(arg),
         }
     }
     let radius: u32 = positional.first().and_then(|s| s.parse().ok()).unwrap_or(3);
@@ -70,6 +72,28 @@ fn main() {
             })
         })
         .collect();
+
+    if json {
+        let entries: Vec<String> = hex_data
+            .iter()
+            .map(|hd| {
+                let corners: Vec<String> = hd
+                    .corners
+                    .iter()
+                    .map(|(x, z)| format!("[{x:.4},{z:.4}]"))
+                    .collect();
+                format!(
+                    r#"{{"center":[{:.4},{:.4}],"corners":[{}],"height":{:.4}}}"#,
+                    hd.center.x,
+                    hd.center.y,
+                    corners.join(","),
+                    hd.height,
+                )
+            })
+            .collect();
+        println!("[{}]", entries.join(","));
+        return;
+    }
 
     let padding = pad;
     let vb_x = min_x - padding;

--- a/crates/hex-grid/examples/svg.rs
+++ b/crates/hex-grid/examples/svg.rs
@@ -34,10 +34,8 @@ fn main() {
     };
     let layout = HGridLayout::from_settings(&settings);
 
-    // Collect hex data for bounds calculation.
     let hexes: Vec<Hex> = shapes::hexagon(Hex::ZERO, settings.radius).collect();
 
-    // World-space bounds (XZ plane, Y is height).
     let mut min_x = f32::MAX;
     let mut max_x = f32::MIN;
     let mut min_z = f32::MAX;
@@ -119,12 +117,17 @@ fn main() {
     let stroke = 0.12;
     let outline = stroke * 3.0;
 
-    // SVG header — transparent background.
+    let points_of = |corners: &[(f32, f32); 6]| {
+        corners
+            .iter()
+            .map(|(x, z)| format!("{x:.2},{z:.2}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+
     println!(
         r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{vb_x:.1} {vb_z:.1} {vb_w:.1} {vb_h:.1}" width="800" height="800">"##,
     );
-
-    // ── Hex faces with height-based fill ────────────────────────
 
     for hd in &hex_data {
         let t = if max_h > 0.0 { hd.height / max_h } else { 0.0 };
@@ -138,82 +141,34 @@ fn main() {
             let v = (60.0 + t * 160.0) as u8;
             (v, v, v)
         };
-
-        let points: String = hd
-            .corners
-            .iter()
-            .map(|(x, z)| format!("{x:.2},{z:.2}"))
-            .collect::<Vec<_>>()
-            .join(" ");
+        let points = points_of(&hd.corners);
         println!(
             r##"  <polygon points="{points}" fill="rgb({r},{g},{b})" stroke="none" opacity="0.9"/>"##,
         );
     }
 
-    // ── Hex face outlines ───────────────────────────────────────
-
-    if rich {
-        for hd in &hex_data {
-            let points: String = hd
-                .corners
-                .iter()
-                .map(|(x, z)| format!("{x:.2},{z:.2}"))
-                .collect::<Vec<_>>()
-                .join(" ");
-            println!(
-                r##"  <polygon points="{points}" fill="none" stroke="white" stroke-width="{outline:.2}" stroke-linejoin="round"/>"##,
-            );
-        }
-        for hd in &hex_data {
-            let points: String = hd
-                .corners
-                .iter()
-                .map(|(x, z)| format!("{x:.2},{z:.2}"))
-                .collect::<Vec<_>>()
-                .join(" ");
-            println!(
-                r##"  <polygon points="{points}" fill="none" stroke="black" stroke-width="{stroke:.2}" stroke-linejoin="round"/>"##,
-            );
-        }
+    let hex_strokes: &[(&str, f32)] = if rich {
+        &[("white", outline), ("black", stroke)]
     } else {
+        &[("gray", stroke)]
+    };
+    for (color, width) in hex_strokes {
         for hd in &hex_data {
-            let points: String = hd
-                .corners
-                .iter()
-                .map(|(x, z)| format!("{x:.2},{z:.2}"))
-                .collect::<Vec<_>>()
-                .join(" ");
+            let points = points_of(&hd.corners);
             println!(
-                r##"  <polygon points="{points}" fill="none" stroke="gray" stroke-width="{stroke:.2}" stroke-linejoin="round"/>"##,
+                r##"  <polygon points="{points}" fill="none" stroke="{color}" stroke-width="{width:.2}" stroke-linejoin="round"/>"##,
             );
         }
     }
 
-    // ── Quad gap long edges (projected to XZ plane) ─────────────
-
-    if rich {
+    for (color, width) in hex_strokes {
         for (from, to) in &long_edges {
             println!(
-                r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="white" stroke-width="{outline:.2}" stroke-linecap="round"/>"##,
-                from.x, from.z, to.x, to.z,
-            );
-        }
-        for (from, to) in &long_edges {
-            println!(
-                r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="black" stroke-width="{stroke:.2}" stroke-linecap="round"/>"##,
-                from.x, from.z, to.x, to.z,
-            );
-        }
-    } else {
-        for (from, to) in &long_edges {
-            println!(
-                r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="gray" stroke-width="{stroke:.2}" stroke-linecap="round"/>"##,
+                r##"  <line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}" stroke="{color}" stroke-width="{width:.2}" stroke-linecap="round"/>"##,
                 from.x, from.z, to.x, to.z,
             );
         }
     }
-
-    // ── Height labels (rich only) ───────────────────────────────
 
     if rich {
         let font = settings.point_spacing * 0.22;

--- a/crates/hex-grid/src/layout.rs
+++ b/crates/hex-grid/src/layout.rs
@@ -161,7 +161,7 @@ impl HGridLayout {
     ///
     /// "Long sides" are the edges that bridge hex→neighbor (v0→n0 and v1→n1),
     /// not the short edges running along each hex's perimeter.
-    pub fn quad_long_edges(&self) -> Vec<(Vec2, Vec2)> {
+    pub fn quad_long_edges(&self) -> Vec<(Vec3, Vec3)> {
         let hexes: Vec<Hex> = shapes::hexagon(Hex::ZERO, self.grid_radius).collect();
         let mut edges = Vec::new();
         for &hex in &hexes {
@@ -178,8 +178,8 @@ impl HGridLayout {
                     self.vertex(hex, v1_idx),
                     self.vertex(neighbor, n1_idx),
                 ) {
-                    edges.push((Vec2::new(a.x, a.z), Vec2::new(b.x, b.z)));
-                    edges.push((Vec2::new(c.x, c.z), Vec2::new(d.x, d.z)));
+                    edges.push((a, b));
+                    edges.push((c, d));
                 }
             }
         }

--- a/web/svg-preview.html
+++ b/web/svg-preview.html
@@ -51,74 +51,83 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 const canvas = document.getElementById('terrain');
-const hexes = await fetch('hex-grid.json').then(r => r.json());
+const data = await fetch('hex-grid.json').then(r => r.json());
+const { hexes, edges } = data;
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0a0e1a);
-scene.fog = new THREE.Fog(0x0a0e1a, 40, 120);
+scene.fog = new THREE.Fog(0x0a0e1a, 40, 140);
 
 const camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientHeight, 0.1, 500);
 
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
 renderer.setPixelRatio(window.devicePixelRatio);
 
-scene.add(new THREE.AmbientLight(0xffffff, 0.35));
-const sun = new THREE.DirectionalLight(0xffffff, 1.1);
+scene.add(new THREE.AmbientLight(0xffffff, 0.45));
+const sun = new THREE.DirectionalLight(0xffffff, 1.0);
 sun.position.set(15, 25, 10);
 scene.add(sun);
-const fill = new THREE.DirectionalLight(0x6ab0ff, 0.25);
-fill.position.set(-10, 5, -10);
+const fill = new THREE.DirectionalLight(0x6ab0ff, 0.3);
+fill.position.set(-10, 8, -10);
 scene.add(fill);
 
 let maxH = 0;
 for (const h of hexes) if (h.height > maxH) maxH = h.height;
 
+// ── Hex face mesh (top face only, one triangle fan per hex) ──
 const positions = [];
 const colors = [];
-const pushTri = (ax, ay, az, bx, by, bz, cx, cy, cz, c) => {
-  positions.push(ax, ay, az, bx, by, bz, cx, cy, cz);
-  for (let i = 0; i < 3; i++) colors.push(c.r, c.g, c.b);
-};
-
-const top = new THREE.Color();
-const side = new THREE.Color();
+const tmp = new THREE.Color();
 
 for (const h of hexes) {
   const t = maxH > 0 ? h.height / maxH : 0;
-  top.setHSL(0.30 - t * 0.18, 0.55, 0.28 + t * 0.38);
-  side.copy(top).multiplyScalar(0.55);
+  tmp.setHSL(0.30 - t * 0.18, 0.55, 0.30 + t * 0.38);
   const [cx, cz] = h.center;
   const y = h.height;
-
   for (let i = 0; i < 6; i++) {
     const [ax, az] = h.corners[i];
     const [bx, bz] = h.corners[(i + 1) % 6];
-    pushTri(cx, y, cz, bx, y, bz, ax, y, az, top);
-  }
-  for (let i = 0; i < 6; i++) {
-    const [ax, az] = h.corners[i];
-    const [bx, bz] = h.corners[(i + 1) % 6];
-    pushTri(ax, y, az, ax, 0, az, bx, 0, bz, side);
-    pushTri(ax, y, az, bx, 0, bz, bx, y, bz, side);
+    positions.push(cx, y, cz, bx, y, bz, ax, y, az);
+    for (let k = 0; k < 3; k++) colors.push(tmp.r, tmp.g, tmp.b);
   }
 }
 
-const geom = new THREE.BufferGeometry();
-geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-geom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
-geom.computeVertexNormals();
-geom.computeBoundingBox();
+const faceGeom = new THREE.BufferGeometry();
+faceGeom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+faceGeom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+faceGeom.computeVertexNormals();
+faceGeom.computeBoundingBox();
 
-const mesh = new THREE.Mesh(
-  geom,
-  new THREE.MeshStandardMaterial({ vertexColors: true, flatShading: true, side: THREE.DoubleSide, roughness: 0.85, metalness: 0.05 }),
-);
-scene.add(mesh);
+scene.add(new THREE.Mesh(
+  faceGeom,
+  new THREE.MeshStandardMaterial({
+    vertexColors: true,
+    flatShading: true,
+    side: THREE.DoubleSide,
+    roughness: 0.85,
+    metalness: 0.05,
+  }),
+));
 
-const bb = geom.boundingBox;
+// ── Quad gap long edges as line segments ─────────────────────
+const edgePositions = new Float32Array(edges.length * 6);
+for (let i = 0; i < edges.length; i++) {
+  const [a, b] = edges[i];
+  edgePositions.set(a, i * 6);
+  edgePositions.set(b, i * 6 + 3);
+}
+const edgeGeom = new THREE.BufferGeometry();
+edgeGeom.setAttribute('position', new THREE.BufferAttribute(edgePositions, 3));
+scene.add(new THREE.LineSegments(
+  edgeGeom,
+  new THREE.LineBasicMaterial({ color: 0x7fc8ff, transparent: true, opacity: 0.8 }),
+));
+
+// ── Camera + controls ────────────────────────────────────────
+const bb = faceGeom.boundingBox;
 const center = bb.getCenter(new THREE.Vector3());
 const size = bb.getSize(new THREE.Vector3()).length();
-camera.position.set(center.x + size * 0.9, center.y + size * 0.7, center.z + size * 0.9);
+camera.position.set(center.x + size * 0.8, center.y + size * 0.6, center.z + size * 0.8);
 
 const controls = new OrbitControls(camera, canvas);
 controls.target.copy(center);

--- a/web/svg-preview.html
+++ b/web/svg-preview.html
@@ -51,107 +51,101 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 const canvas = document.getElementById('terrain');
-const data = await fetch('hex-grid.json').then(r => r.json());
-const { hexes, edges } = data;
 
-const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x0a0e1a);
-scene.fog = new THREE.Fog(0x0a0e1a, 40, 140);
+const showError = (msg) => {
+  canvas.insertAdjacentHTML('afterend',
+    `<p style="color:#f77;text-align:center;padding:0.6rem">${msg}</p>`);
+};
 
-const camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientHeight, 0.1, 500);
+try {
+  const res = await fetch('hex-grid.json');
+  if (!res.ok) throw new Error(`hex-grid.json ${res.status}`);
+  const { hexes, edges } = await res.json();
 
-const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-renderer.setPixelRatio(window.devicePixelRatio);
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0a0e1a);
 
-scene.add(new THREE.AmbientLight(0xffffff, 0.45));
-const sun = new THREE.DirectionalLight(0xffffff, 1.0);
-sun.position.set(15, 25, 10);
-scene.add(sun);
-const fill = new THREE.DirectionalLight(0x6ab0ff, 0.3);
-fill.position.set(-10, 8, -10);
-scene.add(fill);
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
 
-let maxH = 0;
-for (const h of hexes) if (h.height > maxH) maxH = h.height;
+  const camera = new THREE.PerspectiveCamera(
+    45, canvas.clientWidth / canvas.clientHeight, 0.1, 500,
+  );
 
-// ── Hex face mesh (top face only, one triangle fan per hex) ──
-const positions = [];
-const colors = [];
-const tmp = new THREE.Color();
+  scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+  const sun = new THREE.DirectionalLight(0xffffff, 1.0);
+  sun.position.set(15, 25, 10);
+  scene.add(sun);
 
-for (const h of hexes) {
-  const t = maxH > 0 ? h.height / maxH : 0;
-  tmp.setHSL(0.30 - t * 0.18, 0.55, 0.30 + t * 0.38);
-  const [cx, cz] = h.center;
-  const y = h.height;
-  for (let i = 0; i < 6; i++) {
-    const [ax, az] = h.corners[i];
-    const [bx, bz] = h.corners[(i + 1) % 6];
-    positions.push(cx, y, cz, bx, y, bz, ax, y, az);
-    for (let k = 0; k < 3; k++) colors.push(tmp.r, tmp.g, tmp.b);
+  const maxH = hexes.reduce((m, h) => Math.max(m, h.height), 0);
+
+  const positions = [];
+  const colors = [];
+  const tmp = new THREE.Color();
+
+  for (const h of hexes) {
+    const t = maxH > 0 ? h.height / maxH : 0;
+    tmp.setHSL(0.30 - t * 0.18, 0.55, 0.30 + t * 0.38);
+    const [cx, cz] = h.center;
+    const y = h.height;
+    for (let i = 0; i < 6; i++) {
+      const [ax, az] = h.corners[i];
+      const [bx, bz] = h.corners[(i + 1) % 6];
+      positions.push(cx, y, cz, bx, y, bz, ax, y, az);
+      for (let k = 0; k < 3; k++) colors.push(tmp.r, tmp.g, tmp.b);
+    }
   }
-}
 
-const faceGeom = new THREE.BufferGeometry();
-faceGeom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-faceGeom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
-faceGeom.computeVertexNormals();
-faceGeom.computeBoundingBox();
+  const faceGeom = new THREE.BufferGeometry();
+  faceGeom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  faceGeom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  faceGeom.computeVertexNormals();
+  faceGeom.computeBoundingBox();
 
-scene.add(new THREE.Mesh(
-  faceGeom,
-  new THREE.MeshStandardMaterial({
-    vertexColors: true,
-    flatShading: true,
-    side: THREE.DoubleSide,
-    roughness: 0.85,
-    metalness: 0.05,
-  }),
-));
+  scene.add(new THREE.Mesh(faceGeom, new THREE.MeshStandardMaterial({
+    vertexColors: true, flatShading: true, side: THREE.DoubleSide,
+    roughness: 0.85, metalness: 0.05,
+  })));
 
-// ── Quad gap long edges as line segments ─────────────────────
-const edgePositions = new Float32Array(edges.length * 6);
-for (let i = 0; i < edges.length; i++) {
-  const [a, b] = edges[i];
-  edgePositions.set(a, i * 6);
-  edgePositions.set(b, i * 6 + 3);
-}
-const edgeGeom = new THREE.BufferGeometry();
-edgeGeom.setAttribute('position', new THREE.BufferAttribute(edgePositions, 3));
-scene.add(new THREE.LineSegments(
-  edgeGeom,
-  new THREE.LineBasicMaterial({ color: 0x7fc8ff, transparent: true, opacity: 0.8 }),
-));
+  const edgePos = new Float32Array(edges.length * 6);
+  edges.forEach(([a, b], i) => {
+    edgePos.set(a, i * 6);
+    edgePos.set(b, i * 6 + 3);
+  });
+  const edgeGeom = new THREE.BufferGeometry();
+  edgeGeom.setAttribute('position', new THREE.BufferAttribute(edgePos, 3));
+  scene.add(new THREE.LineSegments(edgeGeom, new THREE.LineBasicMaterial({
+    color: 0x7fc8ff, transparent: true, opacity: 0.8,
+  })));
 
-// ── Camera + controls ────────────────────────────────────────
-const bb = faceGeom.boundingBox;
-const center = bb.getCenter(new THREE.Vector3());
-const size = bb.getSize(new THREE.Vector3()).length();
-camera.position.set(center.x + size * 0.8, center.y + size * 0.6, center.z + size * 0.8);
+  const bb = faceGeom.boundingBox;
+  const target = bb.getCenter(new THREE.Vector3());
+  const span = bb.getSize(new THREE.Vector3()).length();
+  camera.position.set(target.x + span * 0.8, target.y + span * 0.6, target.z + span * 0.8);
 
-const controls = new OrbitControls(camera, canvas);
-controls.target.copy(center);
-controls.enableDamping = true;
-controls.dampingFactor = 0.08;
-controls.update();
+  const controls = new OrbitControls(camera, canvas);
+  controls.target.copy(target);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
 
-function resize() {
-  const w = canvas.clientWidth;
-  const h = canvas.clientHeight;
-  if (canvas.width !== w || canvas.height !== h) {
-    renderer.setSize(w, h, false);
-    camera.aspect = w / h;
-    camera.updateProjectionMatrix();
+  function animate() {
+    requestAnimationFrame(animate);
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    if (canvas.width !== w || canvas.height !== h) {
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    }
+    controls.update();
+    renderer.render(scene, camera);
   }
+  animate();
+} catch (e) {
+  console.error(e);
+  showError(`terrain load failed: ${e.message}`);
 }
-
-function animate() {
-  requestAnimationFrame(animate);
-  resize();
-  controls.update();
-  renderer.render(scene, camera);
-}
-animate();
 </script>
 </body>
 </html>

--- a/web/svg-preview.html
+++ b/web/svg-preview.html
@@ -9,12 +9,26 @@
   h1 { margin: 1.5rem 0 0.5rem; font-size: 1.2rem; font-weight: normal; }
   .meta { font-size: 0.8rem; color: #666; margin-bottom: 1rem; }
   .meta a { color: #6a8; }
-  object { width: min(90vw, 800px); height: min(90vw, 800px); }
+  .grid { display: flex; flex-wrap: wrap; justify-content: center; gap: 1.5rem; padding: 0 1rem 2rem; }
+  figure { margin: 0; display: flex; flex-direction: column; align-items: center; }
+  figcaption { font-size: 0.8rem; margin-top: 0.5rem; color: #888; }
+  figcaption a { color: #6a8; }
+  object { width: min(45vw, 500px); height: min(45vw, 500px); }
+  @media (max-width: 720px) { object { width: 90vw; height: 90vw; } }
 </style>
 </head>
 <body>
   <h1>hex-grid terrain preview</h1>
   <p class="meta">generated from <a href="https://github.com/dynnamitt/hex-terrain">dynnamitt/hex-terrain</a> &mdash; <span id="sha">__SHA__</span></p>
-  <object data="hex-grid.svg" type="image/svg+xml">SVG not available</object>
+  <div class="grid">
+    <figure>
+      <object data="hex-grid.svg" type="image/svg+xml">SVG not available</object>
+      <figcaption>plain &mdash; <a href="hex-grid.svg">hex-grid.svg</a></figcaption>
+    </figure>
+    <figure>
+      <object data="hex-grid-rich.svg" type="image/svg+xml">SVG not available</object>
+      <figcaption>rich &mdash; <a href="hex-grid-rich.svg">hex-grid-rich.svg</a></figcaption>
+    </figure>
+  </div>
 </body>
 </html>

--- a/web/svg-preview.html
+++ b/web/svg-preview.html
@@ -9,6 +9,9 @@
   h1 { margin: 1.5rem 0 0.5rem; font-size: 1.2rem; font-weight: normal; }
   .meta { font-size: 0.8rem; color: #666; margin-bottom: 1rem; }
   .meta a { color: #6a8; }
+  .terrain-wrap { width: min(95vw, 1000px); margin-bottom: 1.5rem; }
+  #terrain { display: block; width: 100%; height: min(55vh, 520px); background: #0a0e1a; border-radius: 4px; }
+  .hint { font-size: 0.75rem; color: #556; margin-top: 0.4rem; text-align: center; }
   .grid { display: flex; flex-wrap: wrap; justify-content: center; gap: 1.5rem; padding: 0 1rem 2rem; }
   figure { margin: 0; display: flex; flex-direction: column; align-items: center; }
   figcaption { font-size: 0.8rem; margin-top: 0.5rem; color: #888; }
@@ -16,10 +19,22 @@
   object { width: min(45vw, 500px); height: min(45vw, 500px); }
   @media (max-width: 720px) { object { width: 90vw; height: 90vw; } }
 </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+  }
+}
+</script>
 </head>
 <body>
   <h1>hex-grid terrain preview</h1>
   <p class="meta">generated from <a href="https://github.com/dynnamitt/hex-terrain">dynnamitt/hex-terrain</a> &mdash; <span id="sha">__SHA__</span></p>
+  <div class="terrain-wrap">
+    <canvas id="terrain"></canvas>
+    <p class="hint">drag to orbit &middot; scroll to zoom &middot; right-drag to pan</p>
+  </div>
   <div class="grid">
     <figure>
       <object data="hex-grid.svg" type="image/svg+xml">SVG not available</object>
@@ -30,5 +45,104 @@
       <figcaption>rich &mdash; <a href="hex-grid-rich.svg">hex-grid-rich.svg</a></figcaption>
     </figure>
   </div>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+const canvas = document.getElementById('terrain');
+const hexes = await fetch('hex-grid.json').then(r => r.json());
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x0a0e1a);
+scene.fog = new THREE.Fog(0x0a0e1a, 40, 120);
+
+const camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientHeight, 0.1, 500);
+
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+
+scene.add(new THREE.AmbientLight(0xffffff, 0.35));
+const sun = new THREE.DirectionalLight(0xffffff, 1.1);
+sun.position.set(15, 25, 10);
+scene.add(sun);
+const fill = new THREE.DirectionalLight(0x6ab0ff, 0.25);
+fill.position.set(-10, 5, -10);
+scene.add(fill);
+
+let maxH = 0;
+for (const h of hexes) if (h.height > maxH) maxH = h.height;
+
+const positions = [];
+const colors = [];
+const pushTri = (ax, ay, az, bx, by, bz, cx, cy, cz, c) => {
+  positions.push(ax, ay, az, bx, by, bz, cx, cy, cz);
+  for (let i = 0; i < 3; i++) colors.push(c.r, c.g, c.b);
+};
+
+const top = new THREE.Color();
+const side = new THREE.Color();
+
+for (const h of hexes) {
+  const t = maxH > 0 ? h.height / maxH : 0;
+  top.setHSL(0.30 - t * 0.18, 0.55, 0.28 + t * 0.38);
+  side.copy(top).multiplyScalar(0.55);
+  const [cx, cz] = h.center;
+  const y = h.height;
+
+  for (let i = 0; i < 6; i++) {
+    const [ax, az] = h.corners[i];
+    const [bx, bz] = h.corners[(i + 1) % 6];
+    pushTri(cx, y, cz, bx, y, bz, ax, y, az, top);
+  }
+  for (let i = 0; i < 6; i++) {
+    const [ax, az] = h.corners[i];
+    const [bx, bz] = h.corners[(i + 1) % 6];
+    pushTri(ax, y, az, ax, 0, az, bx, 0, bz, side);
+    pushTri(ax, y, az, bx, 0, bz, bx, y, bz, side);
+  }
+}
+
+const geom = new THREE.BufferGeometry();
+geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+geom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+geom.computeVertexNormals();
+geom.computeBoundingBox();
+
+const mesh = new THREE.Mesh(
+  geom,
+  new THREE.MeshStandardMaterial({ vertexColors: true, flatShading: true, side: THREE.DoubleSide, roughness: 0.85, metalness: 0.05 }),
+);
+scene.add(mesh);
+
+const bb = geom.boundingBox;
+const center = bb.getCenter(new THREE.Vector3());
+const size = bb.getSize(new THREE.Vector3()).length();
+camera.position.set(center.x + size * 0.9, center.y + size * 0.7, center.z + size * 0.9);
+
+const controls = new OrbitControls(camera, canvas);
+controls.target.copy(center);
+controls.enableDamping = true;
+controls.dampingFactor = 0.08;
+controls.update();
+
+function resize() {
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  if (canvas.width !== w || canvas.height !== h) {
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
+  }
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  resize();
+  controls.update();
+  renderer.render(scene, camera);
+}
+animate();
+</script>
 </body>
 </html>


### PR DESCRIPTION
Default output is monochrome: gray height-based fill, single gray stroke,
no text labels. The --rich flag restores the green hue, white+black outlined
strokes, and per-hex height labels.

https://claude.ai/code/session_01U9ZNJ5qEdnqH2ouB4o2dUh