### PR TITLE
Welded hex-terrain demo + weldedMesh rename

### DIFF
--- a/.github/workflows/svg-preview.yml
+++ b/.github/workflows/svg-preview.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "crates/hex-grid/**"
       - "web/svg-preview.html"
+      - "web/hex-terrain.html"
+      - "web/hex-terrain.js"
       - ".github/workflows/svg-preview.yml"
   workflow_dispatch:
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: clean build test coverage coverage-xml inject-updates wasm wasm-deps serve \
-	svg-preview svg-plain svg-rich svg-json svg-html svg-prep
+	svg-preview svg-plain svg-rich svg-json svg-html svg-prep hex-terrain
 
 WASM_OUT = target/wasm
 WASM_BINDGEN_VER := $(shell grep -A1 '^name = "wasm-bindgen"$$' Cargo.lock | grep version | head -1 | cut -d'"' -f2)
@@ -72,5 +72,9 @@ svg-json: svg-prep
 svg-html: svg-prep
 	sed "s|__SHA__|$(SHORT_SHA)|g" web/svg-preview.html > $(SVG_OUT)/index.html
 
-svg-preview: svg-plain svg-rich svg-json svg-html
+hex-terrain: svg-prep
+	sed "s|__SHA__|$(SHORT_SHA)|g" web/hex-terrain.html > $(SVG_OUT)/hex-terrain.html
+	cp web/hex-terrain.js $(SVG_OUT)/hex-terrain.js
+
+svg-preview: svg-plain svg-rich svg-json svg-html hex-terrain
 	@echo "svg preview built in $(SVG_OUT)/"

--- a/crates/hex-grid/examples/svg.rs
+++ b/crates/hex-grid/examples/svg.rs
@@ -100,10 +100,23 @@ fn main() {
                 )
             })
             .collect();
+        let v3 = |v: glam::Vec3| format!("[{:.4},{:.4},{:.4}]", v.x, v.y, v.z);
+        let quad_entries: Vec<String> = layout
+            .gap_quads()
+            .iter()
+            .map(|q| format!("[{},{},{},{}]", v3(q[0]), v3(q[1]), v3(q[2]), v3(q[3])))
+            .collect();
+        let tri_entries: Vec<String> = layout
+            .gap_tris()
+            .iter()
+            .map(|t| format!("[{},{},{}]", v3(t[0]), v3(t[1]), v3(t[2])))
+            .collect();
         println!(
-            "{{\"hexes\":[{}],\"edges\":[{}]}}",
+            "{{\"hexes\":[{}],\"edges\":[{}],\"quads\":[{}],\"tris\":[{}]}}",
             hex_entries.join(","),
             edge_entries.join(","),
+            quad_entries.join(","),
+            tri_entries.join(","),
         );
         return;
     }

--- a/crates/hex-grid/src/layout.rs
+++ b/crates/hex-grid/src/layout.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use glam::{Vec2, Vec3};
-use hexx::{EdgeDirection, Hex, HexLayout, shapes};
+use hexx::{EdgeDirection, GridVertex, Hex, HexLayout, VertexDirection, shapes};
 use noise::{Fbm, MultiFractal, NoiseFn, Perlin};
 
 use crate::math;
@@ -186,6 +186,68 @@ impl HGridLayout {
         edges
     }
 
+    /// Returns the four world-space corners `[hex.v0, neighbor.n0, neighbor.n1, hex.v1]`
+    /// of every gap quad, in CCW order ready for triangulation `[0,1,2,0,2,3]`.
+    /// Same `[0,2,4]` even-edge ownership as [`quad_long_edges`].
+    pub fn gap_quads(&self) -> Vec<[Vec3; 4]> {
+        let hexes: Vec<Hex> = shapes::hexagon(Hex::ZERO, self.grid_radius).collect();
+        let mut quads = Vec::new();
+        for &hex in &hexes {
+            for edge_index in [0u8, 2, 4] {
+                let dir = EdgeDirection::ALL_DIRECTIONS[edge_index as usize];
+                let neighbor = hex.neighbor(dir);
+                if !self.heights.contains_key(&neighbor) {
+                    continue;
+                }
+                let (v0_idx, v1_idx, n0_idx, n1_idx) = math::quad_corner_indices(edge_index);
+                if let (Some(a), Some(b), Some(c), Some(d)) = (
+                    self.vertex(hex, v0_idx),
+                    self.vertex(neighbor, n0_idx),
+                    self.vertex(neighbor, n1_idx),
+                    self.vertex(hex, v1_idx),
+                ) {
+                    quads.push([a, b, c, d]);
+                }
+            }
+        }
+        quads
+    }
+
+    /// Returns the three world-space corners of every 3-hex junction gap tri.
+    /// Canonical ownership: tri emitted only when the origin hex is `coordinates()[0]`.
+    pub fn gap_tris(&self) -> Vec<[Vec3; 3]> {
+        let hexes: Vec<Hex> = shapes::hexagon(Hex::ZERO, self.grid_radius).collect();
+        let mut tris = Vec::new();
+        for &hex in &hexes {
+            for v_idx in [0u8, 1] {
+                let dir = VertexDirection::ALL_DIRECTIONS[v_idx as usize];
+                let gv = GridVertex {
+                    origin: hex,
+                    direction: dir,
+                };
+                let coords = gv.coordinates();
+                if coords[0] != hex {
+                    continue;
+                }
+                if !coords.iter().all(|c| self.heights.contains_key(c)) {
+                    continue;
+                }
+                let idx1 = corner_index_for_vertex(coords[1], &gv);
+                let idx2 = corner_index_for_vertex(coords[2], &gv);
+                if let (Some(i1), Some(i2)) = (idx1, idx2)
+                    && let (Some(v0), Some(v1), Some(v2)) = (
+                        self.vertex(coords[0], v_idx),
+                        self.vertex(coords[1], i1),
+                        self.vertex(coords[2], i2),
+                    )
+                {
+                    tris.push([v0, v1, v2]);
+                }
+            }
+        }
+        tris
+    }
+
     /// Grid radius (number of hex rings around the origin).
     pub fn grid_radius(&self) -> u32 {
         self.grid_radius
@@ -201,6 +263,16 @@ impl HGridLayout {
         math::idw_interpolate_height(pos, &vertices)
             .unwrap_or_else(|| self.heights.get(&hex).copied().unwrap_or(0.0))
     }
+}
+
+fn corner_index_for_vertex(hex: Hex, target: &GridVertex) -> Option<u8> {
+    VertexDirection::ALL_DIRECTIONS.iter().find_map(|&dir| {
+        let candidate = GridVertex {
+            origin: hex,
+            direction: dir,
+        };
+        candidate.equivalent(target).then_some(dir.index())
+    })
 }
 
 #[cfg(test)]

--- a/web/hex-terrain.html
+++ b/web/hex-terrain.html
@@ -51,7 +51,7 @@
 <script type="module">
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import { weldedMeshFromQuads, hexFaceTris, vertexCount, triangleCount } from './hex-terrain.js';
+import { weldedMesh, hexFaceTris, vertexCount, triangleCount } from './hex-terrain.js';
 
 const canvas = document.getElementById('stage');
 const stats = document.getElementById('stats');
@@ -112,7 +112,7 @@ try {
       ...(state.gapTris ? tris : []),
       ...(state.faces ? hexFaceTris(hexes) : []),
     ];
-    const geom = weldedMeshFromQuads(inputQuads, inputTris);
+    const geom = weldedMesh(inputQuads, inputTris);
 
     const mat = new THREE.MeshStandardMaterial({
       color: 0x6c9,

--- a/web/hex-terrain.html
+++ b/web/hex-terrain.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>welded hex terrain</title>
+<style>
+  body { margin: 0; background: #050810; display: flex; flex-direction: column; align-items: center; min-height: 100vh; font-family: monospace; color: #aaa; }
+  h1 { margin: 1.5rem 0 0.25rem; font-size: 1.2rem; font-weight: normal; }
+  .meta { font-size: 0.8rem; color: #666; margin-bottom: 1rem; }
+  .meta a { color: #6a8; }
+  .controls { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.5rem; margin: 0 0 0.6rem; }
+  .controls button {
+    background: #1a2030; color: #9bd; border: 1px solid #2a3550;
+    padding: 0.5rem 0.9rem; font-family: monospace; font-size: 0.85rem;
+    border-radius: 4px; cursor: pointer; min-width: 44px; min-height: 44px;
+  }
+  .controls button.on { background: #2d4470; border-color: #4a6fb0; color: #cde; }
+  .controls button:hover, .controls button:focus { background: #243250; outline: none; }
+  .controls button:active { background: #324570; }
+  .stats { font-size: 0.75rem; color: #667; margin: 0 0 0.6rem; }
+  .stage { width: min(95vw, 1100px); }
+  #stage { display: block; width: 100%; height: min(70vh, 600px); background: #0a0e1a; border-radius: 4px; }
+  .hint { font-size: 0.75rem; color: #556; margin: 0.4rem 0 1.5rem; text-align: center; }
+</style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+  }
+}
+</script>
+</head>
+<body>
+  <h1>welded hex terrain &mdash; one mesh, vec3-deduped</h1>
+  <p class="meta">generated from <a href="https://github.com/dynnamitt/hex-terrain">dynnamitt/hex-terrain</a> &mdash; <span id="sha">__SHA__</span> &middot; <a href="index.html">grid preview</a></p>
+
+  <div class="controls">
+    <button id="btn-fill" type="button" class="on">filled</button>
+    <button id="btn-wire" type="button">wireframe</button>
+    <button id="btn-flat" type="button" class="on">flat shading</button>
+    <button id="btn-faces" type="button" class="on">hex faces</button>
+    <button id="btn-quads" type="button" class="on">gap quads</button>
+    <button id="btn-tris" type="button" class="on">gap tris</button>
+  </div>
+  <p class="stats" id="stats">loading…</p>
+  <div class="stage"><canvas id="stage"></canvas></div>
+  <p class="hint">drag to orbit &middot; scroll to zoom &middot; right-drag to pan</p>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { weldedMeshFromQuads, hexFaceTris, vertexCount, triangleCount } from './hex-terrain.js';
+
+const canvas = document.getElementById('stage');
+const stats = document.getElementById('stats');
+
+const showError = (msg) => {
+  canvas.insertAdjacentHTML('afterend',
+    `<p style="color:#f77;text-align:center;padding:0.6rem">${msg}</p>`);
+};
+
+try {
+  const res = await fetch('hex-grid.json');
+  if (!res.ok) throw new Error(`hex-grid.json ${res.status}`);
+  const { hexes, quads, tris } = await res.json();
+
+  if (!quads) {
+    throw new Error('hex-grid.json is missing the "quads" field — rebuild via `make svg-preview`');
+  }
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x0a0e1a);
+
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
+
+  const camera = new THREE.PerspectiveCamera(45, canvas.clientWidth / canvas.clientHeight, 0.1, 500);
+
+  scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+  const sun = new THREE.DirectionalLight(0xffffff, 1.0);
+  sun.position.set(15, 25, 10);
+  scene.add(sun);
+
+  const state = {
+    fill: true,
+    wire: false,
+    flat: true,
+    faces: true,
+    gapQuads: true,
+    gapTris: true,
+  };
+
+  let mesh = null;
+  let wireOverlay = null;
+
+  const dispose = (obj) => {
+    if (!obj) return;
+    scene.remove(obj);
+    if (obj.geometry) obj.geometry.dispose();
+    if (obj.material) obj.material.dispose();
+  };
+
+  const rebuild = () => {
+    dispose(mesh); mesh = null;
+    dispose(wireOverlay); wireOverlay = null;
+
+    const inputQuads = state.gapQuads ? quads : [];
+    const inputTris = [
+      ...(state.gapTris ? tris : []),
+      ...(state.faces ? hexFaceTris(hexes) : []),
+    ];
+    const geom = weldedMeshFromQuads(inputQuads, inputTris);
+
+    const mat = new THREE.MeshStandardMaterial({
+      color: 0x6c9,
+      flatShading: state.flat,
+      side: THREE.DoubleSide,
+      roughness: 0.85,
+      metalness: 0.05,
+      wireframe: false,
+      visible: state.fill,
+    });
+    mesh = new THREE.Mesh(geom, mat);
+    scene.add(mesh);
+
+    if (state.wire) {
+      const wireGeom = new THREE.WireframeGeometry(geom);
+      wireOverlay = new THREE.LineSegments(wireGeom, new THREE.LineBasicMaterial({
+        color: 0x9bd, transparent: true, opacity: 0.5,
+      }));
+      scene.add(wireOverlay);
+    }
+
+    stats.textContent =
+      `welded vertices: ${vertexCount(geom)} · triangles: ${triangleCount(geom)} ` +
+      `· source quads: ${inputQuads.length} · source tris: ${inputTris.length}`;
+  };
+
+  const wire = (id, key) => {
+    const btn = document.getElementById(id);
+    btn.addEventListener('click', () => {
+      state[key] = !state[key];
+      btn.classList.toggle('on', state[key]);
+      rebuild();
+    });
+  };
+  wire('btn-fill', 'fill');
+  wire('btn-wire', 'wire');
+  wire('btn-flat', 'flat');
+  wire('btn-faces', 'faces');
+  wire('btn-quads', 'gapQuads');
+  wire('btn-tris', 'gapTris');
+
+  rebuild();
+
+  const bb = mesh.geometry.boundingBox;
+  const target = bb.getCenter(new THREE.Vector3());
+  const span = bb.getSize(new THREE.Vector3()).length();
+  camera.position.set(target.x + span * 0.7, target.y + span * 0.5, target.z + span * 0.7);
+
+  const controls = new OrbitControls(camera, canvas);
+  controls.target.copy(target);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+
+  function animate() {
+    requestAnimationFrame(animate);
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    if (canvas.width !== w || canvas.height !== h) {
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    }
+    controls.update();
+    renderer.render(scene, camera);
+  }
+  animate();
+} catch (e) {
+  console.error(e);
+  showError(`terrain load failed: ${e.message}`);
+}
+</script>
+</body>
+</html>

--- a/web/hex-terrain.html
+++ b/web/hex-terrain.html
@@ -38,7 +38,7 @@
 
   <div class="controls">
     <button id="btn-fill" type="button" class="on">filled</button>
-    <button id="btn-wire" type="button">wireframe</button>
+    <button id="btn-wire" type="button" class="on">wireframe</button>
     <button id="btn-flat" type="button" class="on">flat shading</button>
     <button id="btn-faces" type="button" class="on">hex faces</button>
     <button id="btn-quads" type="button" class="on">gap quads</button>
@@ -86,7 +86,7 @@ try {
 
   const state = {
     fill: true,
-    wire: false,
+    wire: true,
     flat: true,
     faces: true,
     gapQuads: true,
@@ -129,7 +129,7 @@ try {
     if (state.wire) {
       const wireGeom = new THREE.WireframeGeometry(geom);
       wireOverlay = new THREE.LineSegments(wireGeom, new THREE.LineBasicMaterial({
-        color: 0x9bd, transparent: true, opacity: 0.5,
+        color: 0xffee44, transparent: true, opacity: 0.5,
       }));
       scene.add(wireOverlay);
     }

--- a/web/hex-terrain.js
+++ b/web/hex-terrain.js
@@ -1,0 +1,73 @@
+import * as THREE from 'three';
+
+const keyOf = (v) => `${v[0]},${v[1]},${v[2]}`;
+
+export function weldedMeshFromQuads(quads, tris = []) {
+  const positions = [];
+  const indices = [];
+  const lookup = new Map();
+
+  const indexOf = (v) => {
+    const k = keyOf(v);
+    let idx = lookup.get(k);
+    if (idx === undefined) {
+      idx = positions.length / 3;
+      positions.push(v[0], v[1], v[2]);
+      lookup.set(k, idx);
+    }
+    return idx;
+  };
+
+  for (const [a, b, c, d] of quads) {
+    const ia = indexOf(a), ib = indexOf(b), ic = indexOf(c), id = indexOf(d);
+    indices.push(ia, ib, ic, ia, ic, id);
+  }
+  for (const [a, b, c] of tris) {
+    indices.push(indexOf(a), indexOf(b), indexOf(c));
+  }
+
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.setIndex(indices);
+  geom.computeVertexNormals();
+  geom.computeBoundingBox();
+  return geom;
+}
+
+export function hexFaceQuads(hexes) {
+  const quads = [];
+  for (const h of hexes) {
+    const [cx, cz] = h.center;
+    const y = h.height;
+    const C = [cx, y, cz];
+    for (const [i, j] of [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 0]]) {
+      const [ax, az] = h.corners[i];
+      const [bx, bz] = h.corners[j];
+      quads.push([C, [ax, y, az], [bx, y, bz], C]);
+    }
+  }
+  return quads;
+}
+
+export function hexFaceTris(hexes) {
+  const tris = [];
+  for (const h of hexes) {
+    const [cx, cz] = h.center;
+    const y = h.height;
+    const C = [cx, y, cz];
+    for (let i = 0; i < 6; i++) {
+      const [ax, az] = h.corners[i];
+      const [bx, bz] = h.corners[(i + 1) % 6];
+      tris.push([C, [ax, y, az], [bx, y, bz]]);
+    }
+  }
+  return tris;
+}
+
+export function vertexCount(geom) {
+  return geom.attributes.position.count;
+}
+
+export function triangleCount(geom) {
+  return geom.index.count / 3;
+}

--- a/web/hex-terrain.js
+++ b/web/hex-terrain.js
@@ -2,7 +2,32 @@ import * as THREE from 'three';
 
 const keyOf = (v) => `${v[0]},${v[1]},${v[2]}`;
 
-export function weldedMeshFromQuads(quads, tris = []) {
+/**
+ * Builds a single indexed `THREE.BufferGeometry` from quad and tri faces,
+ * welding (deduplicating) shared vertex positions so neighboring faces meet
+ * seamlessly and `computeVertexNormals()` produces continuous shading across
+ * the seam.
+ *
+ * Each unique `[x, y, z]` becomes one vertex in the position buffer; faces
+ * become triangle indices into that buffer:
+ *   - Quads `[a, b, c, d]` are triangulated as `(a, b, c)` + `(a, c, d)`
+ *     (CCW fan from `a`).
+ *   - Tris `[a, b, c]` are emitted as-is.
+ *
+ * Welding is exact: vertices are matched by stringified coordinates, so
+ * inputs must already share identical floats at seams (no epsilon merge).
+ *
+ * @param {Array<[Vec3, Vec3, Vec3, Vec3]>} quads - CCW quads, each four
+ *   `[x, y, z]` corners.
+ * @param {Array<[Vec3, Vec3, Vec3]>} [tris=[]] - CCW triangles, each three
+ *   `[x, y, z]` corners. Used for 3-hex junction gaps and (optionally) hex
+ *   face fans.
+ * @returns {THREE.BufferGeometry} Indexed geometry with `position` attribute,
+ *   computed vertex normals, and computed bounding box.
+ *
+ * @typedef {[number, number, number]} Vec3
+ */
+export function weldedMesh(quads, tris = []) {
   const positions = [];
   const indices = [];
   const lookup = new Map();

--- a/web/hex-terrain.md
+++ b/web/hex-terrain.md
@@ -1,0 +1,68 @@
+# Vertex deduplication in `hex-terrain.js`
+
+`weldedMeshFromQuads` (in `hex-terrain.js`) hashes every `[x, y, z]` and
+reuses the index for any exact match, building an indexed
+`THREE.BufferGeometry` instead of a triangle soup. This document explains
+what that buys at the project's current scale and when it would start to
+matter for performance.
+
+## Honest summary
+
+At this scale, **dedup is not a render-speed optimization** — it's a
+topology/shading correctness move. The word "weld" is a tessellation term,
+not a performance term.
+
+## The math at this scale
+
+- Welded mesh: ~150–200 unique vertices, ~300 tris.
+- Without dedup: ~700+ unique vertex slots.
+- Modern GPUs render millions of tris per frame. 700 → 200 vertices saves
+  ~6 KB of position data and a handful of microseconds. Not visible on a
+  frame timer.
+
+## Where indexed welded meshes actually pay off
+
+- **100k+ tris with a non-trivial vertex shader** (skinning, vertex
+  displacement, morph targets): the GPU's post-transform vertex cache
+  reuses shaded vertex outputs when the same vertex is referenced by
+  multiple triangles. Welded + indexed lets that cache hit, maybe
+  1.2–1.5× win.
+- **Memory-constrained targets** (mobile, WebGL on low-end): smaller VBO
+  uploads matter more. Still small at ~300 tris.
+- **CPU-side raycasts / picking**: fewer verts to test. Three.js'
+  `Raycaster` does benefit at large scales.
+
+## What dedup *does* buy in this code
+
+1. **Single connected manifold.** Without bit-exact vertex matching at
+   seams, you'd get hairline cracks where a hex face meets a gap quad —
+   not from rendering artifacts but from floating-point drift if positions
+   were re-emitted from different code paths. The Rust crate's
+   `HGridLayout::vertex(hex, i)` (`crates/hex-grid/src/layout.rs:143-150`)
+   returning identical `Vec3` for shared corners is what makes the weld
+   watertight.
+2. **Free smooth shading at seams** — when `computeVertexNormals()` runs
+   on the indexed mesh, it averages normals across faces sharing a vertex.
+   The hex-face-to-gap-quad transition gets a smoothed normal "for free."
+   You explicitly opt out via `flatShading: true` on the material;
+   three.js then uses per-fragment `dFdx/dFdy` derivatives to fake flat
+   normals, which works on welded meshes too. The "flat shading" toggle
+   in `hex-terrain.html` exposes both modes.
+3. **Cleaner traversal** — `BufferGeometry.attributes.position.count`
+   reflects unique points, useful for diagnostics (the live counter in
+   `hex-terrain.html` shows the welded count).
+
+## What you'd actually want for speed at production scale
+
+- One `BufferGeometry` per mesh (already the case — single draw call).
+- `THREE.BufferGeometryUtils.mergeVertices(geom, tolerance)` to weld
+  post-hoc if you ever load unwelded data (e.g. from a glTF).
+- `THREE.InstancedMesh` if you ever spawn many copies of the same hex chunk.
+- LOD via fewer triangles, not via deduping the same triangles.
+
+## Bottom line
+
+Dedup at our scale is **correctness + ergonomics**, not FPS. If terrain
+grows to grid radius 20+ (~thousands of hexes, ~50k+ tris) the indexed
+post-transform-cache benefit becomes measurable; below that, rendering
+the unwelded version side-by-side won't show a fps difference.

--- a/web/hex-terrain.md
+++ b/web/hex-terrain.md
@@ -1,6 +1,6 @@
 # Vertex deduplication in `hex-terrain.js`
 
-`weldedMeshFromQuads` (in `hex-terrain.js`) hashes every `[x, y, z]` and
+`weldedMesh` (in `hex-terrain.js`) hashes every `[x, y, z]` and
 reuses the index for any exact match, building an indexed
 `THREE.BufferGeometry` instead of a triangle soup. This document explains
 what that buys at the project's current scale and when it would start to

--- a/web/svg-preview.html
+++ b/web/svg-preview.html
@@ -30,7 +30,7 @@
 </head>
 <body>
   <h1>hex-grid terrain preview</h1>
-  <p class="meta">generated from <a href="https://github.com/dynnamitt/hex-terrain">dynnamitt/hex-terrain</a> &mdash; <span id="sha">__SHA__</span></p>
+  <p class="meta">generated from <a href="https://github.com/dynnamitt/hex-terrain">dynnamitt/hex-terrain</a> &mdash; <span id="sha">__SHA__</span> &middot; <a href="hex-terrain.html">welded terrain</a></p>
   <div class="terrain-wrap">
     <canvas id="terrain"></canvas>
     <p class="hint">drag to orbit &middot; scroll to zoom &middot; right-drag to pan</p>


### PR DESCRIPTION
## Summary
- Adds `web/hex-terrain.html` — a three.js demo that takes the rust crate's quad/tri vec3s straight from `hex-grid.json` and welds them into a single indexed `BufferGeometry` (no JS-side tessellation choices, just exact-xyz vertex dedup).
- Rust side: `HGridLayout::gap_quads()` and `gap_tris()` emit gap geometry; `crates/hex-grid/examples/svg.rs` JSON output gains `"quads"` and `"tris"` fields.
- JS side: `weldedMesh(quads, tris)` (renamed from `weldedMeshFromQuads`) with JSDoc covering welding semantics, the CCW-fan triangulation rule, and the exact-match (no-epsilon) caveat.
- Pipeline: `make hex-terrain` target wired into the `svg-preview` aggregate; workflow trigger paths cover the new files.

## Test plan
- [ ] `make svg-preview` builds without errors and emits `hex-terrain.html` + `hex-terrain.js` into the deploy dir
- [ ] Open `hex-terrain.html` from the deployed preview — mesh renders, the six toggle buttons (filled / wireframe / flat shading / hex faces / gap quads / gap tris) all work
- [ ] Toggling **gap tris** off shows triangular holes at every 3-hex junction (confirms tris are needed)
- [ ] Stats line shows welded vertex count is lower than `quads × 4 + tris × 3` (welding actually deduped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)